### PR TITLE
fix package name

### DIFF
--- a/example/example_recursive_test.go
+++ b/example/example_recursive_test.go
@@ -24,7 +24,7 @@ import (
 	"net/rpc"
 	"strings"
 
-	"github.com/soheilhy/cmux"
+	"github.com/supertenant/cmux"
 )
 
 type recursiveHTTPHandler struct{}

--- a/example/example_test.go
+++ b/example/example_test.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/net/websocket"
 
-	"github.com/soheilhy/cmux"
+	"github.com/supertenant/cmux"
 	"google.golang.org/grpc/examples/helloworld/helloworld"
 	grpchello "google.golang.org/grpc/examples/helloworld/helloworld"
 )

--- a/example/example_tls_test.go
+++ b/example/example_tls_test.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/soheilhy/cmux"
+	"github.com/supertenant/cmux"
 )
 
 type anotherHTTPHandler struct{}

--- a/example/go.mod
+++ b/example/go.mod
@@ -1,13 +1,13 @@
-module github.com/soheilhy/cmux/example
+module github.com/supertenant/cmux/example
 
 go 1.11
 
 require (
 	github.com/golang/protobuf v1.4.3 // indirect
-	github.com/soheilhy/cmux v0.0.0-00010101000000-000000000000
+	github.com/supertenant/cmux v0.0.0-00010101000000-000000000000
 	golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb
 	google.golang.org/genproto v0.0.0-20201207150747-9ee31aac76e7 // indirect
 	google.golang.org/grpc v1.27.0
 )
 
-replace github.com/soheilhy/cmux => ../
+replace github.com/supertenant/cmux => ../


### PR DESCRIPTION
When I run go mod tidy on a project that imports `cmux` I get the following error:
```
	github.com/supertenant/cmux: github.com/supertenant/cmux@v0.1.5: parsing go.mod:
	module declares its path as: github.com/soheilhy/cmux
	        but was required as: github.com/supertenant/cmux
```
I am pretty sure it's because there are some imports of the original package name, but even if it won't fix that, it's still wrong to keep the original package name.